### PR TITLE
Create GlobalConfig

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/helpers/utils/GlobalConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/helpers/utils/GlobalConfig.java
@@ -1,0 +1,37 @@
+package org.firstinspires.ftc.teamcode.helpers.utils;
+
+import com.acmerobotics.dashboard.config.Config;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+@Config
+public class GlobalConfig {
+    private static boolean DEBUG_MODE = false;
+
+    private static final Map<ConfigVariable, Object> defaultValueMap = new HashMap<>();
+
+    static {
+        defaultValueMap.put(ConfigVariable.DEBUG_MODE, Boolean.FALSE);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T get(ConfigVariable variable) {
+        try {
+            Field field = GlobalConfig.class.getField(variable.name());
+            Object value = field.get(null);
+            if (value != null) {
+                return (T) value;
+            } else {
+                return (T) defaultValueMap.get(variable);
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+            return (T) defaultValueMap.get(variable);
+        }
+    }
+
+    public enum ConfigVariable {
+        DEBUG_MODE;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/helpers/utils/GlobalConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/helpers/utils/GlobalConfig.java
@@ -7,31 +7,5 @@ import java.util.Map;
 
 @Config
 public class GlobalConfig {
-    private static boolean DEBUG_MODE = false;
-
-    private static final Map<ConfigVariable, Object> defaultValueMap = new HashMap<>();
-
-    static {
-        defaultValueMap.put(ConfigVariable.DEBUG_MODE, Boolean.FALSE);
-    }
-
-    @SuppressWarnings("unchecked")
-    public static <T> T get(ConfigVariable variable) {
-        try {
-            Field field = GlobalConfig.class.getField(variable.name());
-            Object value = field.get(null);
-            if (value != null) {
-                return (T) value;
-            } else {
-                return (T) defaultValueMap.get(variable);
-            }
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            e.printStackTrace();
-            return (T) defaultValueMap.get(variable);
-        }
-    }
-
-    public enum ConfigVariable {
-        DEBUG_MODE;
-    }
+    public static boolean DEBUG_MODE = false;
 }


### PR DESCRIPTION
If it is possible to directly access the newest values of GlobalConfig by just reading public properties, then there is no need for the `get` generic method